### PR TITLE
Fix misnamed method

### DIFF
--- a/Contactscontractexample/src/com/enterpriseandroidbook/contactscontractexample/PickFragment.java
+++ b/Contactscontractexample/src/com/enterpriseandroidbook/contactscontractexample/PickFragment.java
@@ -101,7 +101,7 @@ public class PickFragment extends ListFragment implements
 			Log.i(CLASSNAME, "onStart");
 	}
 
-	public void onresume() {
+	public void onResume() {
 		super.onResume();
 		if (L)
 			Log.i(CLASSNAME, "onResume");


### PR DESCRIPTION
That's why we should always use `@Override`. 😄